### PR TITLE
Chore: limit depth as a function

### DIFF
--- a/packages/strapi-connector-mongoose/lib/mount-models.js
+++ b/packages/strapi-connector-mongoose/lib/mount-models.js
@@ -286,14 +286,15 @@ module.exports = ({ models, target }, ctx) => {
 
 const createOnFetchPopulateFn = ({ morphAssociations, componentAttributes, definition }) => {
   return function() {
-
-    if(strapi.custom && strapi.custom.depthLimit.maxDepth){
-      const depth = (strapi.custom.depthLimit[definition.uid] || 0) + 1;
-      strapi.custom.depthLimit[definition.uid] = depth;
-      if(strapi.custom.depthLimit.fields.includes(definition.uid) && depth > strapi.custom.depthLimit.maxDepth) return;
+    if (
+      strapi.custom &&
+      strapi.custom.limitDepth &&
+      strapi.custom.limitDepth({ definition }) === true
+    ) {
+      return;
     }
 
-    if(strapi.custom && strapi.custom.populate == false) return;
+    if (strapi.custom && strapi.custom.populate == false) return;
 
     const populatedPaths = this.getPopulatedPaths();
 
@@ -324,11 +325,11 @@ const createOnFetchPopulateFn = ({ morphAssociations, componentAttributes, defin
 
 const buildRelation = ({ definition, model, instance, attribute, name }) => {
   const { nature, verbose } =
-  utilsModels.getNature({
-    attribute,
-    attributeName: name,
-    modelName: model.toLowerCase(),
-  }) || {};
+    utilsModels.getNature({
+      attribute,
+      attributeName: name,
+      modelName: model.toLowerCase(),
+    }) || {};
 
   // Build associations key
   utilsModels.defineAssociations(model.toLowerCase(), definition, attribute, name);

--- a/packages/strapi-connector-mongoose/package.json
+++ b/packages/strapi-connector-mongoose/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "strapi-connector-mongoose-modified",
+  "name": "@kai-ai/strapi-connector-mongoose",
   "version": "3.1.11",
   "description": "Mongoose hook for the Strapi framework - modified",
   "homepage": "http://strapi.io",

--- a/packages/strapi-connector-mongoose/package.json
+++ b/packages/strapi-connector-mongoose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-connector-mongoose-modified",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "Mongoose hook for the Strapi framework - modified",
   "homepage": "http://strapi.io",
   "keywords": [


### PR DESCRIPTION
Instead of doing the depth limits logic in strapi connector, use a function to do so instead, keeping the logic in the application